### PR TITLE
Fix type in ContactObject: opted_out_subscription_tyes

### DIFF
--- a/lib/contact/contact.types.ts
+++ b/lib/contact/contact.types.ts
@@ -46,7 +46,7 @@ export interface ContactObject {
     notes: AddressableList;
     companies: AddressableList;
     opted_in_subscription_types: AddressableList;
-    opted_out_subscription_tyes: AddressableList;
+    opted_out_subscription_types: AddressableList;
     referrer: string;
     utm_campaign: string | null;
     utm_content: string | null;


### PR DESCRIPTION


#### Why?

There is a typo in the Contacts object

#### How?

Fix the spelling mistake

```opted_out_subscription_tyes``` => ```opted_out_subscription_types```